### PR TITLE
split up install target for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,17 @@ PREFIX ?= /usr
 
 debug:
 	go build -tags no_emoji -trimpath -o $(NAME)
+.PHONY: debug
 
 release:
 	go build -tags no_emoji -trimpath -ldflags="-s -w" -buildvcs=false -o $(NAME)
+.PHONY: release
 
-install:
+install: install-static
+	sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/
+.PHONY: install
+
+install-static:
 	install -Dm00755 $(NAME) $(DESTDIR)$(PREFIX)/bin/$(NAME)
 	install -Dm00644 internal/assets/icons/icon-512.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/512x512/apps/$(APPID).png
 	install -Dm00644 internal/assets/icons/icon-256.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/256x256/apps/$(APPID).png
@@ -23,7 +29,7 @@ install:
 	install -Dm00644 internal/assets/svg/icon.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/$(APPID).svg
 	install -Dm00644 internal/assets/unix/$(APPID).desktop $(DESTDIR)$(PREFIX)/share/applications/$(APPID).desktop
 	install -Dm00644 internal/assets/unix/$(APPID).appdata.xml $(DESTDIR)$(PREFIX)/share/appdata/$(APPID).appdata.xml
-	sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/
+.PHONY: install-static
 
 uninstall:
 	-rm $(DESTDIR)$(PREFIX)/bin/$(NAME)
@@ -38,3 +44,4 @@ uninstall:
 	-rm $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/$(APPID).svg
 	-rm $(DESTDIR)$(PREFIX)/share/applications/$(APPID).desktop
 	-rm $(DESTDIR)$(PREFIX)/share/appdata/$(APPID).appdata.xml
+.PHONY: uninstall

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,8 @@ release:
 	go build -tags no_emoji -trimpath -ldflags="-s -w" -buildvcs=false -o $(NAME)
 .PHONY: release
 
-install: install-static
-	sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/
-.PHONY: install
-
-install-static:
+install:
+	# You'll maybe want to update your gtk icon cache by running `make update-icon-cache` afterwards.
 	install -Dm00755 $(NAME) $(DESTDIR)$(PREFIX)/bin/$(NAME)
 	install -Dm00644 internal/assets/icons/icon-512.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/512x512/apps/$(APPID).png
 	install -Dm00644 internal/assets/icons/icon-256.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/256x256/apps/$(APPID).png
@@ -29,7 +26,12 @@ install-static:
 	install -Dm00644 internal/assets/svg/icon.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/$(APPID).svg
 	install -Dm00644 internal/assets/unix/$(APPID).desktop $(DESTDIR)$(PREFIX)/share/applications/$(APPID).desktop
 	install -Dm00644 internal/assets/unix/$(APPID).appdata.xml $(DESTDIR)$(PREFIX)/share/appdata/$(APPID).appdata.xml
-.PHONY: install-static
+.PHONY: install
+
+update-icon-cache:
+	sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/
+.PHONY: update-icon-cache
+
 
 uninstall:
 	-rm $(DESTDIR)$(PREFIX)/bin/$(NAME)


### PR DESCRIPTION
### Description:

The AUR package [1] for rymdport uses the install target [2] but there's no need to reload the icon cache when packaging.

This patch splits the install target so that the packaging process can invoke the install-static target without tying to invoke sudo gtk-update-icon-cache.

Existing usage of `make install` should be unaffected.

I've also added [.PHONY targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) to the makefile.

[1] https://aur.archlinux.org/packages/rymdport
[2] https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rymdport#n24

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.